### PR TITLE
Adding French translation of the license

### DIFF
--- a/LICENSE_FR
+++ b/LICENSE_FR
@@ -1,0 +1,20 @@
+COPYRIGHT (c) 2021, Leila Pineda, kris@memeware.net
+
+Ceci est la traduction en français de la licence YMG-v2. Elle ne sert que dans un but informatif, et en aucun cas, n’a d’application légale prenant sur la licence originale.
+
+Le ou les logiciels suivants sont fournis "en tant que tel" sans aucune garantie exprimée ou implicite de quelque nature que ce soit (directement ou indirectement). En aucun cas, les auteurs ne seront tenus responsables des dommages causés par l’utilisation de ce logiciel et de ses dérivés.
+
+L’autorisation d’utiliser, de copier, de modifier, ou bien de distribuer ce logiciel et ses dérivés à quelque fin que ce soit, avec ou sans frais, est accordée par la présente condition que les restrictions suivantes soient respectées :
+
+- L’avis de copyright mentionné ci-dessus doit être inclus dans toutes les copies ou parties substantielles du logiciel.
+
+- Le logiciel ne peut être vendu/distribué en tant que partie d’un logiciel à source fermée. (Exemple : un système d’exploitation à source fermée)
+
+SI VOUS NE SUIVEZ PAS LES RESTRICTIONS ÉNUMÉRÉES CI-DESSUS, OU BIEN NE DONNEZ PAS LE CRÉDIT APPROPRIÉ AUX DÉTENTEURS DE DROITS D'AUTEURS ÉNUMÉRÉS EN HAUT DU DOCUMENT :
+
+- Votre mère est gay.
+- Votre grand-mère est transsexuelle.
+- Personne ne vous aime.
+- Vous êtes plus inutile qu’une merde.
+- La seule chatte que vous avez jamais touchée est votre chat.
+- Vous devez publier le logiciel en tant que source ouverte AVEC les restrictions mentionnées précédemment et donner crédit aux détenteurs de droits d’auteur énumérés en haut de ce document.


### PR DESCRIPTION
This include a legal warning, pointing out that only the license, in his original version, is legaly appliable.
